### PR TITLE
Enable code coverage only for debug builds

### DIFF
--- a/dabirva/build.gradle
+++ b/dabirva/build.gradle
@@ -35,9 +35,10 @@ android {
         debug {
             testCoverageEnabled true
         }
+
         release {
             minifyEnabled false
-            testCoverageEnabled true
+            testCoverageEnabled false
         }
     }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,9 +28,10 @@ android {
         debug {
             testCoverageEnabled true
         }
+
         release {
             minifyEnabled false
-            testCoverageEnabled true
+            testCoverageEnabled false
         }
     }
 


### PR DESCRIPTION
This PR makes sure `org.jacoco.agent` is not listed as runtime dependency in `pom.xml`.